### PR TITLE
fix: waiting for update request to finish before calling fetch

### DIFF
--- a/components/TodoList.tsx
+++ b/components/TodoList.tsx
@@ -63,7 +63,7 @@ export const TodoListFilterContext = createContext<{
 const TodoList: React.FC<{
   tasks: Array<Task>;
   title: string;
-  onUpdateAction: () => void;
+  onUpdateAction: (isUpdating: boolean) => void;
 }> = ({ tasks, title, onUpdateAction }) => {
   const router = useRouter();
   const { appId } = router.query;
@@ -135,7 +135,7 @@ const TodoList: React.FC<{
 
     setTasksByStatus(updatedTasks);
 
-    onUpdateAction();
+    onUpdateAction(true);
     try {
       await fetch(`/api/data?appId=${appId}&recordId=${id}`, {
         method: 'PATCH',
@@ -148,6 +148,8 @@ const TodoList: React.FC<{
       });
     } catch (ex) {
       console.error('Error updating record', ex);
+    } finally {
+      onUpdateAction(false);
     }
   };
 
@@ -264,7 +266,7 @@ const TodoList: React.FC<{
     }));
 
     console.info('tasksByStatus', tasksByStatus);
-    onUpdateAction();
+    onUpdateAction(true);
     try {
       await fetch(`/api/data?appId=${appId}&recordId=${taskId}`, {
         method: 'PATCH',
@@ -277,6 +279,8 @@ const TodoList: React.FC<{
       });
     } catch (ex) {
       console.error('Error updating record', ex);
+    } finally {
+      onUpdateAction(false);
     }
   };
 
@@ -334,7 +338,7 @@ const TodoList: React.FC<{
     }));
 
     try {
-      onUpdateAction();
+      onUpdateAction(true);
       await fetch(`/api/data?appId=${appId}`, {
         method: 'POST',
         headers: {
@@ -348,6 +352,8 @@ const TodoList: React.FC<{
       });
     } catch (error) {
       console.error('Error adding record', error);
+    } finally {
+      onUpdateAction(false);
     }
   };
 

--- a/pages/[appId]/index.tsx
+++ b/pages/[appId]/index.tsx
@@ -46,6 +46,8 @@ const AppPage = ({ clientData, tasks, appConfig }: AppPagePros) => {
   const router = useRouter();
   const { appId } = router.query;
   const [taskLists, setTaskList] = useState<Task[]>(tasks);
+  const isUpdatingTask = useRef(false);
+
   const refreshAppData = async () => {
     const triggerPoolItem = new Date().getTime();
     const getAppDataResult = await fetch(
@@ -58,7 +60,7 @@ const AppPage = ({ clientData, tasks, appConfig }: AppPagePros) => {
     const appData = await getAppDataResult.json();
     const tasks = formatData(clientData, appData);
 
-    if (triggerPoolItem < lastActionTime.current) {
+    if (triggerPoolItem < lastActionTime.current || isUpdatingTask.current) {
       return;
     }
 
@@ -68,9 +70,12 @@ const AppPage = ({ clientData, tasks, appConfig }: AppPagePros) => {
 
   const lastActionTime = useRef(new Date().getTime());
 
-  const handleUpdateAction = () => {
+  const handleUpdateAction = (isUpdating: boolean) => {
     // track the last time the user updated an action
     lastActionTime.current = new Date().getTime();
+
+    // when task update request is pending this will be true
+    isUpdatingTask.current = isUpdating;
   };
 
   useEffect(() => {


### PR DESCRIPTION
### What this does

This PR resolves the issue with update/add new task requests. If update/add request takes longer than 3 sec to complete the GET request updates the task list and we get some weird status jump of task in UI.

### Implementation

Track pending state of add/update requests. And if update/add requests are pending don't hit the GET endpoint.
