### PR TITLE
fix: Incorrect task detail after updating task

### DIFF
--- a/components/TaskCard.tsx
+++ b/components/TaskCard.tsx
@@ -51,7 +51,7 @@ const useStyles = makeStyles<{ viewMode: TodoListViewMode }>()((theme) => ({
 interface TaskCardProps extends Task {
   onStatusChange: (status: TaskStatus) => void;
   viewMode: TodoListViewMode;
-  onTaskOpen: (id: string) => void;
+  onTaskOpen: (id: string, status: string) => void;
 }
 
 const PriorityToComponentMap = {
@@ -112,10 +112,6 @@ const TaskCard = ({
   const openTaskCardMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     return;
-  };
-
-  const openTaskCard = () => {
-    onTaskOpen(id);
   };
 
   return (
@@ -181,7 +177,7 @@ const TaskCard = ({
             <IconButton
               onClick={(event) => {
                 event.stopPropagation();
-                onTaskOpen(id);
+                onTaskOpen(id, status);
               }}
             >
               <OpenInFull

--- a/components/TodoList.tsx
+++ b/components/TodoList.tsx
@@ -183,10 +183,12 @@ const TodoList: React.FC<{
   /**
    * handle task card opened
    */
-  const handleTaskOpen = (taskId: string) => {
+  const handleTaskOpen = (taskId: string, status: string) => {
     // when a taskId is selected we should set the state for the currently select task and use that
     // to show the dialog
-    setSelectedTask(tasks.find((t) => t.id === taskId) || null);
+    setSelectedTask(
+      tasksByStatus[status]?.find((t) => t.id === taskId) || null,
+    );
   };
 
   /**


### PR DESCRIPTION
### What this does

This PR fixes the issue with updated task details where it takes a while for the task description modal to correctly display the updated value.

### Implementation

- Instead of `taskList` state use `tasksByStatus` state to set the `selectedTask` state because once we update the task we are optimistically updating the `taskByStatus` state not the `taskList` state.

