### PR TITLE
fix: add first task from todo app for google sheets only

### DIFF
--- a/components/TodoList.tsx
+++ b/components/TodoList.tsx
@@ -57,7 +57,7 @@ const TodoList: React.FC<{
   onUpdateAction: (id: string) => void;
 }> = ({ tasks, title, onUpdateAction }) => {
   const router = useRouter();
-  const { appId } = router.query;
+  const { appId, clientId } = router.query;
   const { classes } = useStyles();
   const appConfig = useContext(AppContext);
   // Get the current client airtable record ref which lives in the tasks
@@ -349,6 +349,7 @@ const TodoList: React.FC<{
           Name: newTask.title,
           Status: newTask.status,
           'Assignee - Reference Record': clientIdRef,
+          'Assignee ID': clientId,
         }),
       });
     } catch (error) {

--- a/components/types.ts
+++ b/components/types.ts
@@ -41,3 +41,10 @@ export enum TodoListViewMode {
   Board = 'board',
   List = 'list',
 }
+
+export type AddRecordInput = {
+  Name: string;
+  Status: TaskStatus;
+  'Assignee - Reference Record': string | null;
+  'Assignee ID': string;
+};

--- a/pages/api/data/index.ts
+++ b/pages/api/data/index.ts
@@ -81,6 +81,7 @@ const handlePostData = async (req: NextApiRequest, res: NextApiResponse) => {
       );
       res.status(200).json(record);
     } else {
+      delete req.body['Assignee ID']; // we don't need client id for Airtable flow
       // Get the airtable rest client instance
       const airtableClient = getAirtableClient(
         appSetupData.airtableApiKey,


### PR DESCRIPTION
### What this does

[Linear ticket](https://linear.app/copilotplatforms/issue/POR-8140/unable-to-create-first-task-from-todo-app)

This PR fixes the issue with create new task. When user tries to add its first task it is getting saved in the google sheet successful but in not returned by the GET api since the new created record in missing the "Assignee ID".

### Implementation

For first task POST only I am doing following things
1. Fetch all records from "Assignee Map ID" sub sheet.
2. Using `clientId` from todo app URL fetch the "Assignee name" from step 2 records.
3. Send "Assignee name" in POST api to create the new record.

### Testing


https://github.com/copilot-platforms/mahalani/assets/102326359/02f3da77-0f7f-4de6-92c0-587850ef6c6c

Tested this does not affect the current Airtable flow.