### PR TITLE
feat: add routes for CapOne trainings and forms

### DIFF
--- a/components/EmptyPage.tsx
+++ b/components/EmptyPage.tsx
@@ -1,0 +1,33 @@
+import { makeStyles } from '../utils/makeStyles';
+
+const useStyles = makeStyles()(() => ({
+  container: {
+    height: '100%',
+    width: '100%',
+    textAlign: 'center',
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: 700,
+    marginTop: 24,
+    marginBottom: 8,
+  },
+  description: {
+    fontSize: 16,
+  },
+}));
+
+type Props = {
+  title: string;
+  description: string;
+};
+
+export function EmptyPage({ title, description }: Props) {
+  const { classes } = useStyles();
+  return (
+    <div className={classes.container}>
+      <div className={classes.title}>{title}</div>
+      <div className={classes.description}>{description}</div>
+    </div>
+  );
+}

--- a/components/Form/index.tsx
+++ b/components/Form/index.tsx
@@ -1,0 +1,29 @@
+import { makeStyles } from '../../utils/makeStyles';
+
+const LifestyleCollectionForm =
+  'https://www.getfeedback.com/r/eY0V8Q6D/';
+const PremierCollectionForm =
+  'https://www.getfeedback.com/r/uOvgaHrE/';
+
+type FormType = 'lc' | 'pc';
+
+const useStyles = makeStyles()(() => ({
+  container: {
+    position:'absolute',
+    height: '100%',
+    width: '100%',
+  },
+}));
+
+export function CollectionForm({ formType }: { formType: FormType }) {
+  const { classes } = useStyles();
+  return (
+    <div className={classes.container}>
+      <iframe
+        src={formType === 'lc' ? LifestyleCollectionForm : PremierCollectionForm}
+        height="100%"
+        width="100%"
+      ></iframe>
+    </div>
+  );
+}

--- a/components/Training/Training.tsx
+++ b/components/Training/Training.tsx
@@ -1,0 +1,29 @@
+import { makeStyles } from '../../utils/makeStyles';
+
+const LifestyleTrainingDoc =
+  'https://docs.google.com/presentation/d/e/2PACX-1vR6-XC4nSj5WiyGvr_FMY3uZ_I3Bgl8uxIj7t5SLbpdFVG3nwFAhFolHd1QtU2BwIImxjsDvURk1WtM/embed?start=false&loop=false&delayms=60000';
+const PremierTrainingDoc =
+  'https://docs.google.com/presentation/d/e/2PACX-1vQ2feJyRcMtxGOE5o61iNMk2Thi1eMyhF8C4Oko-dMS7n8m4OnWxklRVRSLrXB1T-EDw8Vdn3vcTRkX/embed?start=false&loop=false&delayms=60000';
+
+type TrainingType = 'lc' | 'pc';
+
+const useStyles = makeStyles()(() => ({
+  container: {
+    position:'absolute',
+    height: '100%',
+    width: '100%',
+  },
+}));
+
+export function Training({ trainingType }: { trainingType: TrainingType }) {
+  const { classes } = useStyles();
+  return (
+    <div className={classes.container}>
+      <iframe
+        src={trainingType === 'lc' ? LifestyleTrainingDoc : PremierTrainingDoc}
+        height="100%"
+        width="100%"
+      ></iframe>
+    </div>
+  );
+}

--- a/pages/[appId]/forms/index.tsx
+++ b/pages/[appId]/forms/index.tsx
@@ -1,8 +1,13 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { PageLoader } from '../../../components/PageLoader';
-import { LIFESTYLE_COLLECTION, PREMIER_COLLECTION, PageQuery } from '../trainings';
+import {
+  LIFESTYLE_COLLECTION,
+  PREMIER_COLLECTION,
+  PageQuery,
+} from '../trainings';
 import { CollectionForm } from '../../../components/Form';
+import { EmptyPage } from '../../../components/EmptyPage';
 
 const Forms = () => {
   const [loading, setLoading] = useState(true);
@@ -36,7 +41,7 @@ const Forms = () => {
   };
 
   useEffect(() => {
-    if (!appId || !clientId) return;
+    if (!appId) return;
     loadClientInfo();
   }, [clientId, appId]);
 
@@ -46,21 +51,26 @@ const Forms = () => {
       : '';
 
   function handleRenderIframe() {
-    if (clientCollection) {
-      if (clientCollection === LIFESTYLE_COLLECTION) {
+    const defaultEmptyPage = (
+      <EmptyPage title="Poof!" description="No forms are currently assigned." />
+    );
+
+    if (!clientCollection) {
+      return defaultEmptyPage;
+    }
+
+    switch (clientCollection) {
+      case LIFESTYLE_COLLECTION:
         return <CollectionForm formType="lc" />;
-      } else if (clientCollection === PREMIER_COLLECTION) {
+      case PREMIER_COLLECTION:
         return <CollectionForm formType="pc" />;
-      } else {
-        return <h1>No forms are currently assigned.</h1>;
-      }
-    } else {
-      return <h1>No forms are currently assigned.</h1>;
+      default:
+        return defaultEmptyPage;
     }
   }
 
-  if(loading) {
-    return <PageLoader/>
+  if (loading) {
+    return <PageLoader />;
   }
 
   return <div>{handleRenderIframe()}</div>;

--- a/pages/[appId]/forms/index.tsx
+++ b/pages/[appId]/forms/index.tsx
@@ -1,0 +1,69 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { PageLoader } from '../../../components/PageLoader';
+import { LIFESTYLE_COLLECTION, PREMIER_COLLECTION, PageQuery } from '../trainings';
+import { CollectionForm } from '../../../components/Form';
+
+const Forms = () => {
+  const [loading, setLoading] = useState(true);
+  const [clientInfo, setClientInfo] = useState(null);
+  const router = useRouter();
+  const { appId, clientId, companyId } = router.query as PageQuery;
+
+  const loadClientInfo = async () => {
+    setLoading(true);
+    const query = new URLSearchParams({
+      appId: appId,
+      clientId: clientId,
+      companyId: companyId,
+    });
+    try {
+      const res = await fetch('/api/client-info?' + query, {
+        method: 'GET',
+        headers: {
+          'Content-type': 'application/json',
+        },
+      });
+      const data = await res.json();
+      if (data) {
+        setClientInfo(data);
+      }
+    } catch (error) {
+      console.error('Error fetching client info', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!appId || !clientId) return;
+    loadClientInfo();
+  }, [clientId, appId]);
+
+  const clientCollection =
+    clientInfo?.customFields?.collection?.length > 0
+      ? clientInfo.customFields?.collection[0]
+      : '';
+
+  function handleRenderIframe() {
+    if (clientCollection) {
+      if (clientCollection === LIFESTYLE_COLLECTION) {
+        return <CollectionForm formType="lc" />;
+      } else if (clientCollection === PREMIER_COLLECTION) {
+        return <CollectionForm formType="pc" />;
+      } else {
+        return <h1>No forms are currently assigned.</h1>;
+      }
+    } else {
+      return <h1>No forms are currently assigned.</h1>;
+    }
+  }
+
+  if(loading) {
+    return <PageLoader/>
+  }
+
+  return <div>{handleRenderIframe()}</div>;
+};
+
+export default Forms;

--- a/pages/[appId]/trainings/index.tsx
+++ b/pages/[appId]/trainings/index.tsx
@@ -1,0 +1,80 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import {
+  Training as TrainingIframe,
+} from '../../../components/Training/Training';
+import { PageLoader } from '../../../components/PageLoader';
+
+export type PageQuery = {
+  appId: string;
+  clientId: string;
+  companyId: string;
+};
+
+export const LIFESTYLE_COLLECTION = 'lifestyleCollection';
+export const PREMIER_COLLECTION = 'premierCollection';
+
+const Training = () => {
+  const [loading, setLoading] = useState(true);
+  const [clientInfo, setClientInfo] = useState(null);
+  const router = useRouter();
+  const { appId, clientId, companyId } = router.query as PageQuery;
+
+  const loadClientInfo = async () => {
+    setLoading(true);
+    const query = new URLSearchParams({
+      appId: appId,
+      clientId: clientId,
+      companyId: companyId,
+    });
+    try {
+      const res = await fetch('/api/client-info?' + query, {
+        method: 'GET',
+        headers: {
+          'Content-type': 'application/json',
+        },
+      });
+      const data = await res.json();
+      if (data) {
+        setClientInfo(data);
+      }
+    } catch (error) {
+      console.error('Error fetching client info', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!appId || !clientId) return;
+    loadClientInfo();
+  }, [clientId, appId]);
+
+  const clientCollection =
+    clientInfo?.customFields?.collection?.length > 0
+      ? clientInfo.customFields?.collection[0]
+      : '';
+
+  function handleRenderIframe() {
+    if (clientCollection) {
+      if (clientCollection === LIFESTYLE_COLLECTION) {
+        return <TrainingIframe trainingType="lc" />;
+      } else if (clientCollection === PREMIER_COLLECTION) {
+        return <TrainingIframe trainingType="pc" />;
+      } else {
+        return <h1>No trainings are currently assigned.</h1>;
+      }
+    } else {
+      console.log('client not tagged');
+      return <h1>No trainings are currently assigned.</h1>;
+    }
+  }
+
+  if(loading) {
+    return <PageLoader/>
+  }
+
+  return <div>{handleRenderIframe()}</div>;
+};
+
+export default Training;

--- a/pages/[appId]/trainings/index.tsx
+++ b/pages/[appId]/trainings/index.tsx
@@ -1,9 +1,8 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import {
-  Training as TrainingIframe,
-} from '../../../components/Training/Training';
+import { Training as TrainingIframe } from '../../../components/Training/Training';
 import { PageLoader } from '../../../components/PageLoader';
+import { EmptyPage } from '../../../components/EmptyPage';
 
 export type PageQuery = {
   appId: string;
@@ -46,7 +45,7 @@ const Training = () => {
   };
 
   useEffect(() => {
-    if (!appId || !clientId) return;
+    if (!appId) return;
     loadClientInfo();
   }, [clientId, appId]);
 
@@ -56,22 +55,29 @@ const Training = () => {
       : '';
 
   function handleRenderIframe() {
-    if (clientCollection) {
-      if (clientCollection === LIFESTYLE_COLLECTION) {
+    const defaultEmptyPage = (
+      <EmptyPage
+        title="Poof!"
+        description="No trainings are currently assigned."
+      />
+    );
+
+    if (!clientCollection) {
+      return defaultEmptyPage;
+    }
+
+    switch (clientCollection) {
+      case LIFESTYLE_COLLECTION:
         return <TrainingIframe trainingType="lc" />;
-      } else if (clientCollection === PREMIER_COLLECTION) {
+      case PREMIER_COLLECTION:
         return <TrainingIframe trainingType="pc" />;
-      } else {
-        return <h1>No trainings are currently assigned.</h1>;
-      }
-    } else {
-      console.log('client not tagged');
-      return <h1>No trainings are currently assigned.</h1>;
+      default:
+        return defaultEmptyPage;
     }
   }
 
-  if(loading) {
-    return <PageLoader/>
+  if (loading) {
+    return <PageLoader />;
   }
 
   return <div>{handleRenderIframe()}</div>;

--- a/pages/api/client-info/index.ts
+++ b/pages/api/client-info/index.ts
@@ -1,20 +1,10 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { AppContextType } from '../../../utils/appContext';
 import { fetchConfig } from '../config/apiConfigUtils';
-import { DBType } from '../../[appId]';
-import { isDBUsingGoogleSheets } from '../../../utils/googleSheetUtils';
+import { checkDataLength } from '../initial-data';
 
-//check if data returned
-export const checkDataLength = (dataObj) => {
-  let dataLength;
-  dataObj.data
-    ? (dataLength = Object.keys(dataObj.data).length)
-    : Object.keys(dataObj).length;
-  dataObj.code === 'not_found' ? (dataLength = 0) : null;
-  return dataLength;
-};
 
-const handleLoadInitialData = async (
+const handleLoadClientInfo = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
@@ -80,27 +70,15 @@ const handleLoadInitialData = async (
   } else {
     console.log('No ID Found');
   }
-  const appConfig = {
-    controls: appSetupData.controls || '',
-    defaultChannelType: appSetupData.defaultChannelType || null,
-  };
 
-  const dbType: DBType = isDBUsingGoogleSheets(appSetupData)
-    ? 'google_sheet'
-    : 'airtable';
 
-  // -----------PROPS-----------------------------
-  res.json({
-    clientData,
-    appConfig,
-    dbType,
-  });
+  res.json(clientData);
 };
 
 const handler = (req: NextApiRequest, res: NextApiResponse) => {
   switch (req.method) {
     case 'GET':
-      return handleLoadInitialData(req, res);
+      return handleLoadClientInfo(req, res);
     default:
       return res.status(405).end();
   }


### PR DESCRIPTION
### What this does

This adds `/trainings` and `/forms` routes to display content based upon clients "collection" custom field.
We are doing this for CapitalOne

### Testing

In progress